### PR TITLE
Filtering sub-dirs when unzipping runs in exponential time.  

### DIFF
--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -110,7 +110,6 @@ module.exports = function(grunt) {
         src = file.src,
         srcFiles = grunt.file.expand(src),
         dest = file.dest,
-		flat = file.flat || false,
         router = data.router || echo;
 
     // Fallback options (e.g. checkCRC32)
@@ -132,39 +131,6 @@ module.exports = function(grunt) {
       var files = zip.files,
           filenames = Object.getOwnPropertyNames(files);
 
-	  //If zip file structure is NOT flat, filter out all non-leaf files
-	  if(!flat){		  	 	  		 
-		  filenames = filenames.filter(function filterNonLeafs (filename) {		
-			// Iterate over the other filenames
-			/*
-			 *	NOTE: This process runs in EXPONENTIAL time
-			*/
-			var isLeaf = true,
-				i = filenames.length,
-				otherFile,
-				pathToFile,
-				isParentDir;			 
-			while (i--) {
-			  // If the other file is the current file, skip it
-			  otherFile = filenames[i];		
-			  if (otherFile === filename) {			
-				continue;
-			  }
-
-			  // Determine if this file contains the other
-			  pathToFile = path.relative(filename, otherFile);
-			  isParentDir = pathToFile.indexOf('..') === -1;
-
-			  // If it does, falsify isLeaf
-			  if (isParentDir) {
-				isLeaf = false;
-				break;
-			  }
-			}
-			// Return that the file was a leaf
-			return isLeaf;
-		  });	  
-	  }
       // Iterate over the files   
       filenames.forEach(function (filename) {		
         // Find the content


### PR DESCRIPTION
In release 0.15.0, the process for identifying leaves and filtering sub-dirs when unzipping ran in exponential time.  This made unzipping file with content in the thousands take an inordinate amount of time.

This commit adds an extra parameter called "flat", which can be specified in the config.  If true, then the exponential block is not executed.  If false or unspecified, the filtering block will run.  I'm not sure if the filtering block is completely
necessary.
