### PR TITLE
 Fixed EEXIST when unzipping a symbolic link and a file already exists with that name

### DIFF
--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -158,6 +158,15 @@ module.exports = function(grunt) {
             if ((fileObj.unixPermissions & 0xf000) === 0xa000) {
               var target = content.toString('utf8');
               grunt.verbose.writeln('Creating symbolic link from: "' + filepath + '" to "' + target + '"');
+              // fs.symlinkSync throws EEXIST if a file with the same name as the link already exists
+              try {
+                fs.unlinkSync(filepath);
+              }
+              catch (err) {
+                if (err.code !== 'ENOENT') {
+                  throw err;
+                }
+              }
               fs.symlinkSync(target, filepath);
             } else {
               grunt.verbose.writeln('Writing file: "' + filepath + '"');

--- a/test/utils/grunt.js
+++ b/test/utils/grunt.js
@@ -17,7 +17,7 @@ exports.runTask = function (task) {
       that.stderr = stderr;
 
       // Callback
-      done();
+      done(err);
     });
   });
 


### PR DESCRIPTION
I also made it so that the tests fail if a Grunt task fails, which was hiding this problem. Hope that's ok with you.